### PR TITLE
Add fingerprint to the saved meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paperclip Meta 
+# Paperclip Meta
 
 [![Gem Version](https://badge.fury.io/rb/paperclip-meta.svg)](http://rubygems.org/gems/paperclip-meta)
 [![Build Status](https://travis-ci.org/teeparham/paperclip-meta.svg?branch=master)](https://travis-ci.org/teeparham/paperclip-meta)
@@ -45,13 +45,14 @@ The meta column is simple hash:
 style: {
   width:  100,
   height: 100,
-  size:   42000
+  size:   42000,
+  fingerprint: 'b5ca2374a6cd89c4a971ddeb71f6f86d'
 }
 ```
 
 This hash will be marshaled and base64 encoded before writing to model attribute.
 
-`height`, `width`, and `image_size` methods are provided:
+`height`, `width`, `image_size`, and `fingerprint` methods are provided:
 
 ```ruby
 user.avatar.width(:thumb)
@@ -60,6 +61,10 @@ user.avatar.height(:medium)
 => 200
 user.avatar.image_size
 => '60x70'
+user.avatar.fingerprint
+=> 'b5ca2374a6cd89c4a971ddeb71f6f86d'
+user.avatar.fingerprint(:thumb)
+=> '9c0a079bdd7701d7e729bd956823d153'
 ```
 
 You can pass the image style to these methods. If a style is not passed, the default style will be used.

--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -6,6 +6,7 @@ module Paperclip
         base.alias_method_chain :save, :meta_data
         base.alias_method_chain :post_process_styles, :meta_data
         base.alias_method_chain :size, :meta_data
+        base.alias_method_chain :fingerprint, :meta_data
       end
 
       module InstanceMethods
@@ -31,6 +32,10 @@ module Paperclip
           style ? read_meta(style, :size) : size_without_meta_data
         end
 
+        def fingerprint_with_meta_data(style = nil)
+          read_meta(style || :original, :fingerprint)
+        end
+
         def height(style = default_style)
           read_meta style, :height
         end
@@ -52,7 +57,10 @@ module Paperclip
           queue.each do |style, file|
             begin
               geo = Geometry.from_file file
-              meta[style] = { width: geo.width.to_i, height: geo.height.to_i, size: file.size }
+              meta[style] = { width: geo.width.to_i,
+                              height: geo.height.to_i,
+                              size: file.size,
+                              fingerprint: file.fingerprint }
             rescue Paperclip::Errors::NotIdentifiedByImageMagickError
               meta[style] = {}
             end


### PR DESCRIPTION
I forked this gem to allow us to store the meta data about our offer images into the database.  It provided 99% of the framework to do that.  It was missing one core piece of information that we needed though, which is the md5 hash of the image.   This PR updates the forked gem to include the `fingerprint` (i.e. md5 hash) of the image into the meta data.

The next step will be plugging it into our offers.

PT story: https://www.pivotaltracker.com/story/show/76550702
