### PR TITLE
Use meta for fingerprint only when available

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -32,8 +32,11 @@ module Paperclip
           style ? read_meta(style, :size) : size_without_meta_data
         end
 
-        def fingerprint_with_meta_data(style = nil)
-          read_meta(style || :original, :fingerprint)
+        def fingerprint_with_meta_data(style = :original)
+          fingerprint = fingerprint_without_meta_data if style == :original
+          return fingerprint if fingerprint
+
+          read_meta(style, :fingerprint)
         end
 
         def height(style = default_style)

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -69,6 +69,15 @@ describe "Attachment" do
       fingerprint = fingerprint_for(path)
       assert_equal fingerprint, image.big_image.fingerprint(:thumb)
     end
+
+    it 'favor use of #{image_name}_fingerprint for original image' do
+      image = Image.create(big_image: big_image)
+      image.update_attribute(:big_image_meta, nil)
+      path = File.join(File.dirname(__FILE__), "tmp/fixtures/tmp/original/#{image.id}.jpg")
+      fingerprint = fingerprint_for(path)
+      assert_nil image.big_image_meta
+      assert_equal fingerprint, image.big_image.fingerprint
+    end
   end
 
   it "clears geometry fields when image is destroyed" do

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -10,6 +10,7 @@ ActiveRecord::Schema.define do
     t.string  :big_image_content_type
     t.integer :big_image_updated_at
     t.integer :big_image_file_size
+    t.string  :big_image_fingerprint
     t.string  :big_image_meta
   end
 end


### PR DESCRIPTION
It's possible to configure paperclip to store the original files 'fingerprint' in the '#{image_name}_fingerprint' column.  This modifies the change to the fingerprint method to favor using that value when it's present, otherwise looking up the value from the meta data.
