### PR TITLE
Add rake task for reprocessing only meta data

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -21,7 +21,11 @@ module Paperclip
           post_process_styles_without_meta_data(*styles)
           return unless instance.respond_to?(:"#{name}_meta=")
 
-          meta = populate_meta(@queued_for_write)
+          process_meta_for_styles(@queued_for_write)
+        end
+
+        def process_meta_for_styles(queue)
+          meta = populate_meta(queue)
           return if meta == {}
 
           write_meta(meta)
@@ -51,6 +55,15 @@ module Paperclip
         # return dimesions for default_style.
         def image_size(style = default_style)
           "#{width(style)}x#{height(style)}"
+        end
+
+        # Helper method to return a read only version of the meta hash for
+        # the instance
+        #
+        def meta_data
+          if instance.respond_to?(:"#{name}_meta") && instance_read(:meta)
+            meta_decode(instance_read(:meta)).freeze
+          end
         end
 
         private

--- a/lib/paperclip-meta/process_meta_service.rb
+++ b/lib/paperclip-meta/process_meta_service.rb
@@ -1,0 +1,68 @@
+module Paperclip
+  module Meta
+
+    class ProcessMetaService
+
+      def self.process!(logger = nil)
+        class_names = ENV['CLASSES'] || ENV['classes']
+        classes = class_names.split(',').map { |class_name| Paperclip.class_for(class_name) }
+        self.new(logger).process!(*classes)
+      end
+
+      attr_accessor :logger
+
+      def initialize(logger = nil)
+        @logger = logger
+      end
+
+      def process!(*classes)
+        classes.each do |klass|
+          process_class(klass)
+        end
+      end
+
+      private
+
+      def process_class(klass)
+        attachments = Paperclip::AttachmentRegistry.names_for(klass)
+        raise "Class #{klass.name} has no attachments specified" if attachments.empty?
+
+        klass.unscoped.each do |instance|
+          log("Processing image meta data for #{instance.class}.#{instance.id}")
+          attachments.each do |attachment_name|
+            next if instance.send(attachment_name).blank?
+            process_attachment(instance, attachment_name)
+          end
+        end
+      end
+
+      def process_attachment(instance, attachment_name)
+        meta_attribute_name = "#{attachment_name}_meta"
+        return unless instance.respond_to?(meta_attribute_name)
+
+        attachment = instance.send(attachment_name)
+        io_hash = attachment_styles_to_io_adapters(attachment)
+        attachment.process_meta_for_styles(io_hash)
+        instance.update_column(meta_attribute_name, instance.send(meta_attribute_name))
+      end
+
+      def attachment_styles_to_io_adapters(attachment)
+        io_hash = attachment.styles.reduce({}) do |hash, (style_name, style)|
+          hash[style_name] = Paperclip.io_adapters.for(style)
+          hash
+        end
+
+        unless io_hash.has_key?(:original)
+          io_hash[:original] = Paperclip.io_adapters.for(attachment)
+        end
+
+        io_hash
+      end
+
+      def log(*args)
+        logger.info(*args) if logger
+      end
+
+    end
+  end
+end

--- a/lib/paperclip-meta/railtie.rb
+++ b/lib/paperclip-meta/railtie.rb
@@ -2,13 +2,18 @@ require 'paperclip-meta'
 
 module Paperclip
   module Meta
-    
+
     if defined? ::Rails::Railtie
       class Railtie < ::Rails::Railtie
         initializer :paperclip_meta do
           ActiveSupport.on_load :active_record do
             Paperclip::Meta::Railtie.insert
           end
+        end
+
+        rake_tasks do
+          dir = File.join(File.dirname(__FILE__),'../../tasks/*.rake')
+          Dir[dir].each { |f| load f }
         end
       end
     end

--- a/spec/process_meta_service_spec.rb
+++ b/spec/process_meta_service_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+require 'paperclip-meta/process_meta_service'
+
+describe "ProcessMetaService" do
+
+  before do
+    Image.delete_all
+    ImageWithNoValidation.delete_all
+    @service = Paperclip::Meta::ProcessMetaService.new
+    @images = [ Image.create!(small_image: small_image),
+                Image.create!(small_image: small_image, big_image: big_image),
+                Image.create! ]
+    Image.update_all(small_image_meta: nil, big_image_meta: nil)
+  end
+
+  it 'reprocesses all the attachments meta data' do
+    images = Image.where('small_image_meta is not null or big_image_meta is not null')
+    assert_equal 0, images.count
+
+    @service.process!(Image)
+
+    assert_equal 2, images.count
+    assert_equal(small_image_meta, images.first.small_image.meta_data)
+    assert_equal(small_image_meta, images.last.small_image.meta_data)
+    assert_equal(big_image_meta, images.last.big_image.meta_data)
+  end
+
+  private
+
+  def small_path
+    File.join(File.dirname(__FILE__), 'fixtures', 'small.png')
+  end
+
+  # 50x64
+  def small_image
+    File.open(small_path)
+  end
+
+  def small_image_meta
+    { original: { width: 50,
+                  height: 64,
+                  size: 6646,
+                  fingerprint: "9c0a079bdd7701d7e729bd956823d153" }}
+  end
+
+  def big_image_meta
+    { thumb: { width: 100,
+               height: 100,
+               size: 3475,
+               fingerprint: "b5ca2374a6cd89c4a971ddeb71f6f86d"},
+      large: { width: 500,
+               height: 500,
+               size: 37801,
+               fingerprint: "f2e4b93cb207a29fdb5ca23bfda3a599"},
+      original: { width: 600,
+                  height: 277,
+                  size: 37042,
+                  fingerprint: "3b26372629ef054dd31f02cb0c6d64b0"}}
+  end
+
+  def geometry_for(path)
+    Paperclip::Geometry.from_file(path)
+  end
+
+  def fingerprint_for(path)
+    Digest::MD5.file(path).hexdigest
+  end
+
+  # 600x277
+  def big_image
+    File.open(File.join(File.dirname(__FILE__), 'fixtures', 'big.jpg'))
+  end
+
+  def not_image
+    File.open(File.join(File.dirname(__FILE__), 'fixtures', 'big.zip'))
+  end
+end

--- a/tasks/reprocess_meta.rake
+++ b/tasks/reprocess_meta.rake
@@ -1,0 +1,9 @@
+require 'paperclip-meta/process_meta_service'
+
+namespace :paperclip_meta do
+
+  desc 'Regenerate only the paperclip-meta without reprocessing the images themselves'
+  task :reprocess => :environment do
+    Paperclip::Meta::ProcessMetaService.process!(Rails.logger)
+  end
+end


### PR DESCRIPTION
The previous way of generating meta data for existing
Paperclip::Attachments was to reprocess them all.  For existing
implementations with lots of records and many styles that take time to
resize and process thumbnails that could be a lot of overkill.   This
creates a simple task that only generates the meta data for existing
attachments and their styles.
