### PR TITLE
Use the default fingerprint when style is nil

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -37,7 +37,7 @@ module Paperclip
         end
 
         def fingerprint_with_meta_data(style = :original)
-          fingerprint = fingerprint_without_meta_data if style == :original
+          fingerprint = fingerprint_without_meta_data if style == nil || style == :original
           return fingerprint if fingerprint
 
           read_meta(style.to_sym, :fingerprint)

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -78,6 +78,7 @@ describe "Attachment" do
       fingerprint = fingerprint_for(path)
       assert_nil image.big_image_meta
       assert_equal fingerprint, image.big_image.fingerprint
+      assert_equal fingerprint, image.big_image.fingerprint(nil)
     end
   end
 


### PR DESCRIPTION
An explicyt 'nil' argument may be passed, and for that case
just use the original fingerprint.
